### PR TITLE
Sleep 5 seconds after receiving a Too Many Requests error

### DIFF
--- a/archiveurl
+++ b/archiveurl
@@ -60,9 +60,9 @@ while read line; do
                 "${toarchive}")
 
     if [[ "$code" == 2* ]]; then
-        echo "Archived: ${url}"
+        echo "Archived (${code}): ${url}"
     else
-        >&2 echo "Failed: ${url}"
+        >&2 echo "Failed (${code}): ${url}"
     fi
 done < "${1:-/dev/stdin}"
 

--- a/archiveurl
+++ b/archiveurl
@@ -63,6 +63,10 @@ while read line; do
         echo "Archived (${code}): ${url}"
     else
         >&2 echo "Failed (${code}): ${url}"
+        if [[ "$code" == 429 ]]; then
+            # Too Many Requests error - pause before sending next request
+            sleep 5
+        fi
     fi
 done < "${1:-/dev/stdin}"
 


### PR DESCRIPTION
Addresses https://github.com/OpenBookPublishers/archiveurl/issues/1. Picked 5 seconds as an arbitrary value that worked well in testing. A more robust solution would check whether a `Retry-After` header value was specified and use that.